### PR TITLE
Interactivity added for Itinerary page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@fortawesome/vue-fontawesome": "^3.0.3",
         "vue": "^3.2.47",
         "vue-router": "^4.1.6",
+        "vuedraggable": "^4.1.0",
         "vuetify": "^3.1.8"
       },
       "devDependencies": {
@@ -2734,6 +2735,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/sortablejs": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.14.0.tgz",
+      "integrity": "sha512-pBXvQCs5/33fdN1/39pPL0NZF20LeRbLQ5jtnheIPN9JQAaufGjKdWduZn4U7wCtVuzKhmRkI0DFYHYRbB2H1w=="
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -3020,6 +3026,17 @@
       },
       "peerDependencies": {
         "vue": "^3.2.0"
+      }
+    },
+    "node_modules/vuedraggable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vuedraggable/-/vuedraggable-4.1.0.tgz",
+      "integrity": "sha512-FU5HCWBmsf20GpP3eudURW3WdWTKIbEIQxh9/8GE806hydR9qZqRRxRE3RjqX7PkuLuMQG/A7n3cfj9rCEchww==",
+      "dependencies": {
+        "sortablejs": "1.14.0"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.1"
       }
     },
     "node_modules/vuetify": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@fortawesome/vue-fontawesome": "^3.0.3",
     "vue": "^3.2.47",
     "vue-router": "^4.1.6",
+    "vuedraggable": "^4.1.0",
     "vuetify": "^3.1.8"
   },
   "devDependencies": {

--- a/src/components/GlobalComponents/ExpandableMap.vue
+++ b/src/components/GlobalComponents/ExpandableMap.vue
@@ -12,9 +12,11 @@
 .map-wrapper {
     position: fixed;
     right: 0;
-    width: 28%;
+    width: 29%;
     height: 90%;
     box-shadow: inset 7px 0 8px -7px var(--dark-grey-primary);
+    z-index: 100;
+    background-color: green;
 }
 
 /* h1 margin for fomatting */

--- a/src/components/ItineraryPage/DestinationContainer.vue
+++ b/src/components/ItineraryPage/DestinationContainer.vue
@@ -1,0 +1,30 @@
+<template>
+    <div>
+        <DestinationItem 
+            v-for="(destItem, index) in destItems"
+            :key = index
+            :title = destItem.title
+            :description= destItem.description
+            :imageSource = destItem.imageSource
+            :imageAlt = destItem.imageAlt
+        />
+    </div>
+</template>
+
+<script setup>
+import DestinationItem from './DestinationItem.vue';
+import { ref } from 'vue';
+
+// replace this with API array of destItems object later 
+const destItems = ref([
+    {title: 'Marina Bay Sands', description: 'This is MBS.', imageSource: "", imageAlt: "MBS image"},
+    {title: 'Merlion', description: 'This is Merlion Park', imageSource: "../../assets/images/destination-item-image.jpg", imageAlt: "Merlion image"}
+]) 
+
+
+</script>
+
+
+<style scoped>
+
+</style>

--- a/src/components/ItineraryPage/DestinationContainer.vue
+++ b/src/components/ItineraryPage/DestinationContainer.vue
@@ -7,6 +7,7 @@
             :description= destItem.description
             :imageSource = destItem.imageSource
             :imageAlt = destItem.imageAlt
+            @removeItem=removeItem(index)
         />
     </div>
 </template>
@@ -17,9 +18,16 @@ import { ref } from 'vue';
 
 // replace this with API array of destItems object later 
 const destItems = ref([
-    {title: 'Marina Bay Sands', description: 'This is MBS.', imageSource: "", imageAlt: "MBS image"},
-    {title: 'Merlion', description: 'This is Merlion Park', imageSource: "../../assets/images/destination-item-image.jpg", imageAlt: "Merlion image"}
-]) 
+    {title: 'Marina Bay Sands', description: 'This is MBS.', imageSource: "../../assets/images/destination-item-image.jpg", imageAlt: "MBS image"},
+    {title: 'Merlion', description: 'This is Merlion Park', imageSource: "", imageAlt: "Merlion image"},
+    {title: 'Gardens By the Bay', description: 'This is Gardens by the Bay', imageSource: "", imageAlt: "Garden image"},
+    {title: 'Bugis Street', description: 'This is Bugis Street', imageSource: "", imageAlt: "Bugis image"}
+])
+
+function removeItem(index) {
+    destItems.value.splice(index, 1)
+}
+
 
 
 </script>

--- a/src/components/ItineraryPage/DestinationItem.vue
+++ b/src/components/ItineraryPage/DestinationItem.vue
@@ -3,10 +3,10 @@
         <div class="destination-wrapper">
             <div class="destination-title-wrapper">
                 <div>
-                    <font-awesome-icon icon="fa-solid fa-location-pin" />
+                    <font-awesome-icon icon="fa-solid fa-location-pin"/>
                     <span class="destination-title">{{ props.title }}</span>
                 </div>
-                <font-awesome-icon icon="fa-solid fa-trash" />
+                <font-awesome-icon icon="fa-solid fa-trash" @click="$emit('removeItem')"/>
             </div>
 
             <p class="destination-description">{{ props.description }}</p>
@@ -29,7 +29,7 @@ const props = defineProps([
     'title', 
     'description',
     'imageSource',
-    'imageAlt'
+    'imageAlt',
 ])
 
 </script>

--- a/src/components/ItineraryPage/DestinationItem.vue
+++ b/src/components/ItineraryPage/DestinationItem.vue
@@ -95,4 +95,8 @@ const props = defineProps([
 .fa-trash {
     cursor: pointer;
 }
+
+.fa-trash:hover {
+    color: red;
+}
 </style>

--- a/src/components/ItineraryPage/DestinationItem.vue
+++ b/src/components/ItineraryPage/DestinationItem.vue
@@ -13,7 +13,7 @@
         </div>
 
         <div class="destination-image-wrapper">
-            <img :src=props.imageSource :alt=props.imageAlt>
+            <img src="../../assets/images/destination-item-image.jpg" :alt=props.imageAlt>
         </div>
     </div>
 </template>
@@ -40,7 +40,6 @@ const props = defineProps([
     display: flex;
     align-items: center;
     justify-content: space-between;
-    width: var(--expanded-map-width);
     margin: 1em;
 }
 
@@ -58,7 +57,7 @@ const props = defineProps([
     border-radius: 10px;
 }
 .destination-wrapper {
-    width: 80%;
+    width: 100%;
     height: 132px;
     background: var(--light-grey-primary);
     border-radius: 10px;

--- a/src/components/ItineraryPage/DestinationItem.vue
+++ b/src/components/ItineraryPage/DestinationItem.vue
@@ -4,23 +4,16 @@
             <div class="destination-title-wrapper">
                 <div>
                     <font-awesome-icon icon="fa-solid fa-location-pin" />
-                    <span class="destination-title">Marina Bay Sands</span>
+                    <span class="destination-title">{{ props.title }}</span>
                 </div>
                 <font-awesome-icon icon="fa-solid fa-trash" />
             </div>
 
-            <p class="destination-description">
-                Lorem, ipsum dolor sit amet consectetur adipisicing elit. Iste dolor nihil, 
-                consequuntur laborum mollitia modi aliquam. Neque iste alias amet corrupti repellendus 
-                suscipit vitae mollitia. Consectetur qui officiis tempore numquam.
-                Lorem, ipsum dolor sit amet consectetur adipisicing elit. Iste dolor nihil, 
-                consequuntur laborum mollitia modi aliquam. Neque iste alias amet corrupti repellendus 
-                suscipit vitae mollitia. Consectetur qui officiis tempore numquam.
-            </p>
+            <p class="destination-description">{{ props.description }}</p>
         </div>
 
         <div class="destination-image-wrapper">
-            <img src="../../assets/images/destination-item-image.jpg" alt="destination-item-image">
+            <img :src=props.imageSource :alt=props.imageAlt>
         </div>
     </div>
 </template>
@@ -30,6 +23,15 @@ import { library } from '@fortawesome/fontawesome-svg-core'
 import { faLocationPin, faTrash } from '@fortawesome/free-solid-svg-icons'
 
 library.add(faLocationPin, faTrash)
+
+
+const props = defineProps([
+    'title', 
+    'description',
+    'imageSource',
+    'imageAlt'
+])
+
 </script>
 
 <style scoped>

--- a/src/components/ItineraryPage/ItineraryHeader.vue
+++ b/src/components/ItineraryPage/ItineraryHeader.vue
@@ -1,6 +1,7 @@
 <template>
     <div class="header-wrapper">
-        <font-awesome-icon icon="fa-solid fa-map" class="expand-map-button"/>
+        <font-awesome-icon icon="fa-solid fa-circle-chevron-left" class="expand-map-button" @click="$emit('toggleMap')" v-if="props.changeIcon"/>
+        <font-awesome-icon icon="fa-solid fa-map" class="expand-map-button" @click="$emit('toggleMap')" v-else/>
         <div class="image-wrapper">
             <img src="../../assets/images/itinerary-header-image.jpg" alt="header-image">
         </div>
@@ -10,7 +11,7 @@
             
             <button class="share-button">
                 <span>Share Itinerary</span>
-                <font-awesome-icon icon="fa-solid fa-link" />
+                <font-awesome-icon icon="fa-solid fa-link"/>
             </button>
         </div>
     </div>
@@ -18,17 +19,20 @@
 
 <script setup>
 import { library } from '@fortawesome/fontawesome-svg-core'
-import { faPen, faLink, faMap } from '@fortawesome/free-solid-svg-icons'
+import { faPen, faLink, faMap, faCircleChevronLeft } from '@fortawesome/free-solid-svg-icons'
 import ItineraryTitle from './ItineraryTitle.vue';
 
-library.add(faPen, faLink, faMap)
+library.add(faPen, faLink, faMap, faCircleChevronLeft)
+
+const props = defineProps([
+    'changeIcon'
+])
 
 </script>
 
 <style scoped>
 
 .header-wrapper {
-    width: calc(var(--expanded-map-width) + 1em);
     height: 250px;
     position: relative;
 }
@@ -36,7 +40,7 @@ library.add(faPen, faLink, faMap)
     display: flex;
     justify-content: center;
     align-items: center;
-    z-index: 1;
+    width: 100%;
 }
 
 .image-wrapper img {
@@ -56,7 +60,7 @@ library.add(faPen, faLink, faMap)
 .share-button {
   background-color: var(--white-background-primary);
   color: var(--black-text-primary);
-  width: 160px;
+  width: 180px;
   height: 42px;
   border-radius: 10px;
   font-size: 16px;
@@ -77,5 +81,10 @@ library.add(faPen, faLink, faMap)
     color: var(--white-background-primary);
     cursor: pointer;
 }
+
+.expand-map-button:hover {
+    opacity: 0.8;
+}
+
 
 </style>

--- a/src/components/ItineraryPage/ItineraryHeader.vue
+++ b/src/components/ItineraryPage/ItineraryHeader.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="header-wrapper">
-        <font-awesome-icon icon="fa-solid fa-circle-chevron-left" class="expand-map-button" @click="$emit('toggleMap')" v-if="props.changeIcon"/>
+        <font-awesome-icon icon="fa-solid fa-circle-chevron-right" class="expand-map-button" @click="$emit('toggleMap')" v-if="props.changeIcon"/>
         <font-awesome-icon icon="fa-solid fa-map" class="expand-map-button" @click="$emit('toggleMap')" v-else/>
         <div class="image-wrapper">
             <img src="../../assets/images/itinerary-header-image.jpg" alt="header-image">
@@ -19,10 +19,10 @@
 
 <script setup>
 import { library } from '@fortawesome/fontawesome-svg-core'
-import { faPen, faLink, faMap, faCircleChevronLeft } from '@fortawesome/free-solid-svg-icons'
+import { faPen, faLink, faMap, faCircleChevronRight } from '@fortawesome/free-solid-svg-icons'
 import ItineraryTitle from './ItineraryTitle.vue';
 
-library.add(faPen, faLink, faMap, faCircleChevronLeft)
+library.add(faPen, faLink, faMap, faCircleChevronRight)
 
 const props = defineProps([
     'changeIcon'

--- a/src/components/ItineraryPage/ItineraryHeader.vue
+++ b/src/components/ItineraryPage/ItineraryHeader.vue
@@ -6,11 +6,8 @@
         </div>
         
         <div class="header-details-wrapper">
-            <div class="header-title-wrapper">
-                <span class="header-title-text">Trip to Singapore</span>
-                <a href="#"><font-awesome-icon icon="fa-solid fa-pen" /></a>
-            </div>
-
+            <ItineraryTitle />
+            
             <button class="share-button">
                 <span>Share Itinerary</span>
                 <font-awesome-icon icon="fa-solid fa-link" />
@@ -22,6 +19,7 @@
 <script setup>
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { faPen, faLink, faMap } from '@fortawesome/free-solid-svg-icons'
+import ItineraryTitle from './ItineraryTitle.vue';
 
 library.add(faPen, faLink, faMap)
 
@@ -53,28 +51,6 @@ library.add(faPen, faLink, faMap)
     align-items: center;
     position: relative;
     bottom: 4em
-}
-
-.header-title-wrapper {
-    color: var(--white-background-primary);
-    display: flex;
-    align-items: center;
-    justify-content: space-evenly;
-    width: 420px;
-    height: 60px;
-}
-
-.fa-pen {
-    height: 25px;
-    width: 25px;
-    color: white;
-    position: relative;
-    top: 1.5px
-}
-
-.header-title-text {
-    font-size: 40px;
-    font-weight: 600;
 }
 
 .share-button {

--- a/src/components/ItineraryPage/ItineraryTitle.vue
+++ b/src/components/ItineraryPage/ItineraryTitle.vue
@@ -1,0 +1,53 @@
+<template>
+    <div class="header-title-wrapper">
+        <!-- <span class="header-title-text">Trip to Singapore</span> -->
+        
+        <input class="header-title-text" v-model="titleInput" placeholder="Add Itinerary Title"/>
+    </div>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue';
+
+const titleInput = ref('')
+
+// write newTitleInput into firebase to update
+watch(titleInput, (newTitleInput) => {
+    console.log(newTitleInput)
+})
+
+</script>
+
+<style scoped>
+
+.header-title-wrapper {
+    color: var(--white-background-primary);
+    display: flex;
+    align-items: center;
+    justify-content: space-evenly;
+    width: 100%;
+    height: 60px;
+    position: relative;
+    margin-left: 10px;
+}
+
+.header-title-text {
+    font-size: 40px;
+    font-weight: 600;
+    height: 60px;
+    width: 100%;
+    position: absolute;
+    color: white;
+}
+
+input:focus {
+    outline: none;
+    border: none;
+}
+
+::placeholder {
+    color: white;
+    opacity: 0.8;
+}
+
+</style>

--- a/src/views/ItineraryView.vue
+++ b/src/views/ItineraryView.vue
@@ -1,20 +1,38 @@
 <template>
     <div class="view">
-        <ExpandableMap />
-        <ItineraryHeader />
-        <DestinationContainer />
+        <ExpandableMap v-show="toggle"/>
+        <div :class="toggle === true ? 'openMap' : 'closeMap'" >
+            <ItineraryHeader @toggleMap=toggleMap() :changeIcon="toggle"/>
+            <DestinationContainer />
+        </div>
     </div>
     <RouterView />
 </template>
 
 <script setup>
 import { RouterView } from 'vue-router';
+import { ref } from 'vue';
 import ItineraryHeader from '../components/ItineraryPage/ItineraryHeader.vue';
 import ExpandableMap from '../components/GlobalComponents/ExpandableMap.vue';
 import DestinationContainer from '../components/ItineraryPage/DestinationContainer.vue';
 
+const toggle = ref(true)
+
+function toggleMap() {
+    toggle.value = !toggle.value
+    console.log(toggle.value)
+}
+
 </script>
 
 <style scoped>
+
+.openMap {
+    width: var(--expanded-map-width);
+}
+
+.closeMap {
+    width: 100%;
+}
 
 </style>

--- a/src/views/ItineraryView.vue
+++ b/src/views/ItineraryView.vue
@@ -1,28 +1,11 @@
 <template>
     <div class="view">
-        <!-- Uncomment to test page -->
-        <!-- <ExpandableMap />
-        <LocationCard />
-        <ItineraryHeader />
-        <DestinationItem />
-        <DestinationItem />
-        <DestinationItem />
-        <DestinationItem />
-        <DestinationItem />
-        <DestinationItem />
-        <DestinationItem />
-        <DestinationItem />
-        <DestinationItem /> -->
     </div>
     <RouterView />
 </template>
 
 <script setup>
 import { RouterView } from 'vue-router';
-import DestinationItem from '../components/ItineraryPage/DestinationItem.vue';
-import ExpandableMap from '../components/GlobalComponents/ExpandableMap.vue';
-import ItineraryHeader from '../components/ItineraryPage/ItineraryHeader.vue';
-import LocationCard from '../components/GlobalComponents/LocationCard.vue';
 
 </script>
 

--- a/src/views/ItineraryView.vue
+++ b/src/views/ItineraryView.vue
@@ -1,11 +1,17 @@
 <template>
     <div class="view">
+        <ExpandableMap />
+        <ItineraryHeader />
+        <DestinationContainer />
     </div>
     <RouterView />
 </template>
 
 <script setup>
 import { RouterView } from 'vue-router';
+import ItineraryHeader from '../components/ItineraryPage/ItineraryHeader.vue';
+import ExpandableMap from '../components/GlobalComponents/ExpandableMap.vue';
+import DestinationContainer from '../components/ItineraryPage/DestinationContainer.vue';
 
 </script>
 

--- a/src/views/WishlistView.vue
+++ b/src/views/WishlistView.vue
@@ -5,9 +5,7 @@
 </template>
 
 <script setup>
-
 </script>
 
 <style scoped>
-
 </style>


### PR DESCRIPTION
**What has changed ?**
- `<DestinationItem props />` accepts props and its dynamic now. 
- Able to delete item with trash can icon
- Can open and close map drawer, icon will change when toggled. (p.s. I use v-show and some CSS to do this drawer so rendering time is reduced) 
- ItineraryTitle is an input now and give "tap to edit" feeling --> this feature is not completed yet (haven't tried autosaving it with firestore) 

<img width="1467" alt="Screenshot 2023-03-28 at 17 59 47" src="https://user-images.githubusercontent.com/99931775/228202254-13afcc84-fbdd-44ed-bc01-2857673e56c9.png">

